### PR TITLE
Gracefully continue on unknown Telnet opt

### DIFF
--- a/crates/icy_net/src/connection/telnet/mod.rs
+++ b/crates/icy_net/src/connection/telnet/mod.rs
@@ -187,7 +187,7 @@ impl TelnetConnection {
                 },
                 ParserState::Will => {
                     self.state = ParserState::Data;
-                    match telnet_option::check(b)? {
+                    match b {
                         telnet_option::TRANSMIT_BINARY => {
                             self.tcp_stream
                                 .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DO, telnet_option::TRANSMIT_BINARY))
@@ -210,13 +210,15 @@ impl TelnetConnection {
                     }
                 }
                 ParserState::Wont => {
-                    let opt = telnet_option::check(b)?;
-                    log::info!("Wont {opt:?}");
+                    if !telnet_option::is_supported(b) {
+                        log::warn!("unsupported wont option {}", telnet_option::to_string(b));
+                    }
+                    log::info!("Wont {b:?}");
                     self.state = ParserState::Data;
                 }
                 ParserState::Do => {
                     self.state = ParserState::Data;
-                    let opt = telnet_option::check(b)?;
+                    let opt = b;
                     match opt {
                         telnet_option::TRANSMIT_BINARY => {
                             self.tcp_stream
@@ -245,8 +247,10 @@ impl TelnetConnection {
                     }
                 }
                 ParserState::Dont => {
-                    let opt = telnet_option::check(b)?;
-                    log::info!("Dont {opt:?}");
+                    if !telnet_option::is_supported(b) {
+                        log::warn!("unsupported dont option {}", telnet_option::to_string(b));
+                    }
+                    log::info!("Dont {b:?}");
                     self.state = ParserState::Data;
                 }
             }

--- a/crates/icy_net/src/connection/telnet/mod.rs
+++ b/crates/icy_net/src/connection/telnet/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::{
+    collections::HashMap,
     io::{self, ErrorKind},
     time::Duration,
 };
@@ -16,8 +17,11 @@ use crate::ConnectionState;
 
 use super::{Connection, ConnectionType};
 
+mod negotiation;
 mod telnet_cmd;
 mod telnet_option;
+
+use negotiation::Negotiation;
 
 #[derive(Debug)]
 enum ParserState {
@@ -63,6 +67,11 @@ pub struct TelnetConnection {
     caps: TermCaps,
     state: ParserState,
     read_buffer: Vec<u8>,
+    is_server: bool,
+    /// RFC 1143 negotiation state for the remote side (incoming WILL/WONT).
+    remote_neg: HashMap<u8, Negotiation>,
+    /// RFC 1143 negotiation state for the local side (incoming DO/DONT).
+    local_neg: HashMap<u8, Negotiation>,
 }
 
 impl TelnetConnection {
@@ -79,6 +88,9 @@ impl TelnetConnection {
                     caps,
                     state: ParserState::Data,
                     read_buffer: Vec::new(),
+                    is_server: false,
+                    remote_neg: HashMap::new(),
+                    local_neg: HashMap::new(),
                 }),
                 Err(err) => Err(Box::new(err)),
             },
@@ -95,7 +107,36 @@ impl TelnetConnection {
             },
             state: ParserState::Data,
             read_buffer: Vec::new(),
+            is_server: true,
+            remote_neg: HashMap::new(),
+            local_neg: HashMap::new(),
         })
+    }
+
+    fn agree_remote(opt: u8, is_server: bool) -> bool {
+        if is_server {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::TERMINAL_TYPE | telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE)
+        } else {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::ECHO | telnet_option::SUPPRESS_GO_AHEAD)
+        }
+    }
+
+    fn agree_local(opt: u8, is_server: bool) -> bool {
+        if is_server {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::ECHO | telnet_option::SUPPRESS_GO_AHEAD)
+        } else {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::TERMINAL_TYPE | telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE)
+        }
+    }
+
+    async fn send_negotiation_reply(&mut self, reply: negotiation::Reply, opt: u8) -> io::Result<()> {
+        use negotiation::Reply;
+        match reply {
+            Reply::Do => self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DO, opt)).await,
+            Reply::Dont => self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DONT, opt)).await,
+            Reply::Will => self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::WILL, opt)).await,
+            Reply::Wont => self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::WONT, opt)).await,
+        }
     }
 
     async fn parse(&mut self, data: &mut [u8]) -> io::Result<usize> {
@@ -187,71 +228,52 @@ impl TelnetConnection {
                 },
                 ParserState::Will => {
                     self.state = ParserState::Data;
-                    match b {
-                        telnet_option::TRANSMIT_BINARY => {
-                            self.tcp_stream
-                                .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DO, telnet_option::TRANSMIT_BINARY))
-                                .await?;
-                        }
-                        telnet_option::ECHO => {
-                            self.tcp_stream
-                                .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DO, telnet_option::ECHO))
-                                .await?;
-                        }
-                        telnet_option::SUPPRESS_GO_AHEAD => {
-                            self.tcp_stream
-                                .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DO, telnet_option::SUPPRESS_GO_AHEAD))
-                                .await?;
-                        }
-                        opt => {
-                            log::warn!("unsupported will option {}", telnet_option::to_string(opt));
-                            self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::DONT, opt)).await?;
-                        }
+                    let agree = Self::agree_remote(b, self.is_server);
+                    let neg = self.remote_neg.get(&b).copied().unwrap_or_default();
+                    let (new_neg, reply) = neg.on_will(agree);
+                    self.remote_neg.insert(b, new_neg);
+                    if let Some(reply) = reply {
+                        self.send_negotiation_reply(reply, b).await?;
                     }
                 }
                 ParserState::Wont => {
-                    if !telnet_option::is_supported(b) {
-                        log::warn!("unsupported wont option {}", telnet_option::to_string(b));
+                    self.state = ParserState::Data;
+                    let neg = self.remote_neg.get(&b).copied().unwrap_or_default();
+                    let (new_neg, reply) = neg.on_wont();
+                    self.remote_neg.insert(b, new_neg);
+                    if let Some(reply) = reply {
+                        self.send_negotiation_reply(reply, b).await?;
                     }
                     log::info!("Wont {b:?}");
-                    self.state = ParserState::Data;
                 }
                 ParserState::Do => {
                     self.state = ParserState::Data;
-                    let opt = b;
-                    match opt {
-                        telnet_option::TRANSMIT_BINARY => {
-                            self.tcp_stream
-                                .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::WILL, telnet_option::TRANSMIT_BINARY))
-                                .await?;
-                        }
-                        telnet_option::TERMINAL_TYPE => {
-                            self.tcp_stream
-                                .write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::WILL, telnet_option::TERMINAL_TYPE))
-                                .await?;
-                        }
-                        telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE => {
-                            // NAWS: send our current window size
-                            let mut buf: Vec<u8> = telnet_cmd::make_cmd_with_option(telnet_cmd::SB, telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE).to_vec();
-                            // Note: big endian bytes are correct.
-                            buf.extend(self.caps.window_size.0.to_be_bytes());
-                            buf.extend(self.caps.window_size.1.to_be_bytes());
-                            buf.push(telnet_cmd::IAC);
-                            buf.push(telnet_cmd::SE);
-                            self.tcp_stream.write_all(&buf).await?;
-                        }
-                        _ => {
-                            log::warn!("unsupported do option {}", telnet_option::to_string(opt));
-                            self.tcp_stream.write_all(&telnet_cmd::make_cmd_with_option(telnet_cmd::WONT, opt)).await?;
-                        }
+                    let agree = Self::agree_local(b, self.is_server);
+                    let neg = self.local_neg.get(&b).copied().unwrap_or_default();
+                    let (new_neg, reply) = neg.on_do(agree);
+                    self.local_neg.insert(b, new_neg);
+                    let has_reply = reply.is_some();
+                    if let Some(reply) = reply {
+                        self.send_negotiation_reply(reply, b).await?;
+                    }
+                    if b == telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE && has_reply {
+                        let mut buf: Vec<u8> = telnet_cmd::make_cmd_with_option(telnet_cmd::SB, telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE).to_vec();
+                        buf.extend(self.caps.window_size.0.to_be_bytes());
+                        buf.extend(self.caps.window_size.1.to_be_bytes());
+                        buf.push(telnet_cmd::IAC);
+                        buf.push(telnet_cmd::SE);
+                        self.tcp_stream.write_all(&buf).await?;
                     }
                 }
                 ParserState::Dont => {
-                    if !telnet_option::is_supported(b) {
-                        log::warn!("unsupported dont option {}", telnet_option::to_string(b));
+                    self.state = ParserState::Data;
+                    let neg = self.local_neg.get(&b).copied().unwrap_or_default();
+                    let (new_neg, reply) = neg.on_dont();
+                    self.local_neg.insert(b, new_neg);
+                    if let Some(reply) = reply {
+                        self.send_negotiation_reply(reply, b).await?;
                     }
                     log::info!("Dont {b:?}");
-                    self.state = ParserState::Data;
                 }
             }
         }
@@ -377,5 +399,60 @@ impl Connection for TelnetConnection {
     async fn shutdown(&mut self) -> crate::Result<()> {
         self.tcp_stream.shutdown().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agree_remote(opt: u8, is_server: bool) -> bool {
+        if is_server {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::TERMINAL_TYPE | telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE)
+        } else {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::ECHO | telnet_option::SUPPRESS_GO_AHEAD)
+        }
+    }
+
+    fn agree_local(opt: u8, is_server: bool) -> bool {
+        if is_server {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::ECHO | telnet_option::SUPPRESS_GO_AHEAD)
+        } else {
+            matches!(opt, telnet_option::TRANSMIT_BINARY | telnet_option::TERMINAL_TYPE | telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE)
+        }
+    }
+
+    #[test]
+    fn agree_remote_directionality() {
+        // Client: wants server to do BINARY, ECHO, SGA; refuses TTYPE, NAWS
+        assert!(agree_remote(telnet_option::TRANSMIT_BINARY, false));
+        assert!(agree_remote(telnet_option::ECHO, false));
+        assert!(agree_remote(telnet_option::SUPPRESS_GO_AHEAD, false));
+        assert!(!agree_remote(telnet_option::TERMINAL_TYPE, false));
+        assert!(!agree_remote(telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE, false));
+
+        // Server: wants client to do BINARY, TTYPE, NAWS; refuses ECHO, SGA
+        assert!(agree_remote(telnet_option::TRANSMIT_BINARY, true));
+        assert!(agree_remote(telnet_option::TERMINAL_TYPE, true));
+        assert!(agree_remote(telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE, true));
+        assert!(!agree_remote(telnet_option::ECHO, true));
+        assert!(!agree_remote(telnet_option::SUPPRESS_GO_AHEAD, true));
+    }
+
+    #[test]
+    fn agree_local_directionality() {
+        // Client: will do BINARY, TTYPE, NAWS; refuses ECHO, SGA
+        assert!(agree_local(telnet_option::TRANSMIT_BINARY, false));
+        assert!(agree_local(telnet_option::TERMINAL_TYPE, false));
+        assert!(agree_local(telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE, false));
+        assert!(!agree_local(telnet_option::ECHO, false));
+        assert!(!agree_local(telnet_option::SUPPRESS_GO_AHEAD, false));
+
+        // Server: will do BINARY, ECHO, SGA; refuses TTYPE, NAWS
+        assert!(agree_local(telnet_option::TRANSMIT_BINARY, true));
+        assert!(agree_local(telnet_option::ECHO, true));
+        assert!(agree_local(telnet_option::SUPPRESS_GO_AHEAD, true));
+        assert!(!agree_local(telnet_option::TERMINAL_TYPE, true));
+        assert!(!agree_local(telnet_option::NEGOTIATE_ABOUT_WINDOW_SIZE, true));
     }
 }

--- a/crates/icy_net/src/connection/telnet/telnet_option.rs
+++ b/crates/icy_net/src/connection/telnet/telnet_option.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 /**
 <http://www.iana.org/assignments/telnet-options/telnet-options.xhtml>
 */
@@ -103,14 +101,8 @@ pub const TEL_OPT_PRAGMA_HEARTBEAT: u8 = 140;
 /// <https://www.rfc-editor.org/rfc/rfc861>
 pub const EXTENDED_OPTIONS_LIST: u8 = 0xFF;
 
-pub fn check(byte: u8) -> io::Result<u8> {
-    match byte {
-        0..=49 | 138..=140 | 255 => Ok(byte),
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("unknown option: {byte}/x{byte:02X}"),
-        )),
-    }
+pub fn is_supported(byte: u8) -> bool {
+    matches!(byte, 0..=49 | 138..=140 | 255)
 }
 
 pub fn to_string(byte: u8) -> &'static str {
@@ -164,5 +156,18 @@ pub fn to_string(byte: u8) -> &'static str {
         TEL_OPT_PRAGMA_HEARTBEAT => "TelOptPragmaHeartbeat",
         EXTENDED_OPTIONS_LIST => "ExtendedOptionsList",
         _ => "Unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_supported_correct_for_all_bytes() {
+        for byte in 0..=255u8 {
+            let expected = matches!(byte, 0..=49 | 138..=140 | 255);
+            assert_eq!(is_supported(byte), expected);
+        }
     }
 }


### PR DESCRIPTION
**This Problem**: if a server requests for any option that Icy Term does not support it displays an error and hangs up, when it should use IAC negotiation to decline unsupported offers and gracefully continue.

<img width="1231" height="938" alt="icyterm-before" src="https://github.com/user-attachments/assets/563c222a-b682-402a-b8da-05dc6be1dbbb" />

**Another Problem** This parser is not safe from "telnet loops".

The telnet parser is not using [RFC 1143](https://datatracker.ietf.org/doc/html/rfc1143) rule 3, "Remember DONT/WONT requests", and Rule 4, explained therein, this causes "telnet loops" with a server that is also not RFC 1143 complaint (and many are not).

For example, server says IAC WILL BINARY, so icy_term replies, IAC DO BINARY, server sees the DO and agrees again, IAC WILL BINARY, icy_term sees the WILL and agrees again, IAC DO BINARY, and so on.

**First Solution**: Refactor ``check`` to ``is_supported``, and add log::warn calls for unsupported options and gracefully continue.

**Second Solution**: Implement RFC 1143 to prevent "telnet loops"**

- [x] **STILL WIP: 

<img width="1231" height="938" alt="icyterm-after" src="https://github.com/user-attachments/assets/6ebda4fc-ce0e-49fa-b041-4024e044571a" />

Demonstration Server ([requires telnetlib3](https://github.com/jquast/telnetlib3/)):
```python
#!/usr/bin/env python3
import asyncio
import telnetlib3
import logging

async def shell(reader, writer):
    # send 'IAC WILL 50', out of range/unsupported
    writer.iac(telnetlib3.WILL, b'2')
    # icy_term disconnects, other terminals continue ...
    writer.write('\r\nWhat is your name: ')
    user = await reader.readline()
    writer.write('\r\nWelcome, ' + user.rstrip() + '!\r\n')
    await writer.drain()
    writer.close()

async def main():
    logging.basicConfig(level=logging.DEBUG)
    logging.getLogger("telnetlib3").setLevel(logging.DEBUG)
    server = await telnetlib3.create_server("127.0.0.1", 6023, shell=shell, connect_maxwait=0.1)
    await server.wait_closed()

asyncio.run(main())
```