### PR TITLE
icy_net: optional SOCKS5 proxy for TCP connections (Tor/I2P)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,6 +4052,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-socks",
  "tokio-tungstenite",
  "url",
  "webpki-roots 1.0.9",
@@ -10121,6 +10122,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/crates/icy_net/Cargo.toml
+++ b/crates/icy_net/Cargo.toml
@@ -18,6 +18,8 @@ regex = { workspace = true }
 async-trait =  { workspace = true }
 
 bytes = "1"
+# PROXY (SOCKS5 with remote DNS, for Tor/I2P)
+tokio-socks = "0.5"
 # MODEM
 serial2-tokio = { version = "0.1.25", features = ["unix"] }
 

--- a/crates/icy_net/src/connection/mod.rs
+++ b/crates/icy_net/src/connection/mod.rs
@@ -1,6 +1,7 @@
 use crate::NetError;
 pub mod channel;
 pub mod modem;
+pub mod proxy;
 pub mod raw;
 pub mod rlogin;
 pub mod serial;

--- a/crates/icy_net/src/connection/proxy.rs
+++ b/crates/icy_net/src/connection/proxy.rs
@@ -1,0 +1,88 @@
+//! Per-connection proxy support.
+//!
+//! Currently only SOCKS5 with *remote* DNS is supported. That is exactly what
+//! is needed to reach BBSes over Tor (`.onion`) and I2P (`.i2p`): the target
+//! hostname must be resolved by the proxy, not locally.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpStream;
+use tokio_socks::tcp::Socks5Stream;
+
+/// Kind of proxy. Only SOCKS5 is supported for now; kept as an enum so other
+/// kinds can be added without changing the config shape.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProxyKind {
+    #[default]
+    Socks5,
+}
+
+/// Per-connection proxy configuration.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyConfig {
+    pub kind: ProxyKind,
+    pub host: String,
+    pub port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+}
+
+impl ProxyConfig {
+    /// SOCKS5 proxy without authentication (e.g. Tor at 127.0.0.1:9050).
+    pub fn socks5(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            kind: ProxyKind::Socks5,
+            host: host.into(),
+            port,
+            username: None,
+            password: None,
+        }
+    }
+}
+
+fn err(msg: &str) -> Box<dyn std::error::Error + Send + Sync> {
+    msg.into()
+}
+
+/// Split a `host:port` endpoint without resolving the host, so DNS can happen
+/// at the proxy (required for `.onion` / `.i2p`). Handles bracketed IPv6.
+fn split_host_port(endpoint: &str) -> crate::Result<(String, u16)> {
+    let endpoint = endpoint.trim();
+    if let Some(rest) = endpoint.strip_prefix('[') {
+        let close = rest.find(']').ok_or_else(|| err("unterminated IPv6 literal in proxy target"))?;
+        let host = &rest[..close];
+        let port = rest[close + 1..]
+            .strip_prefix(':')
+            .and_then(|p| p.parse().ok())
+            .ok_or_else(|| err("proxy target must be host:port"))?;
+        return Ok((host.to_string(), port));
+    }
+    let (host, port) = endpoint.rsplit_once(':').ok_or_else(|| err("proxy target must be host:port"))?;
+    let port: u16 = port.parse().map_err(|_| err("invalid proxy target port"))?;
+    Ok((host.to_string(), port))
+}
+
+/// Open a TCP connection to `endpoint` (`host:port`), optionally through a
+/// proxy. With a SOCKS5 proxy the hostname is resolved by the proxy (remote
+/// DNS), so `.onion` and `.i2p` targets work.
+pub async fn connect_tcp(endpoint: &str, proxy: Option<&ProxyConfig>, timeout: Duration) -> crate::Result<TcpStream> {
+    match proxy {
+        None => Ok(tokio::time::timeout(timeout, TcpStream::connect(endpoint)).await??),
+        Some(proxy) => {
+            let (host, port) = split_host_port(endpoint)?;
+            let proxy_addr = format!("{}:{}", proxy.host, proxy.port);
+            let target = (host.as_str(), port);
+            let connect = async {
+                match (proxy.username.as_deref(), proxy.password.as_deref()) {
+                    (Some(user), Some(pass)) => Socks5Stream::connect_with_password(proxy_addr.as_str(), target, user, pass).await,
+                    _ => Socks5Stream::connect(proxy_addr.as_str(), target).await,
+                }
+            };
+            let stream = tokio::time::timeout(timeout, connect).await??;
+            Ok(stream.into_inner())
+        }
+    }
+}

--- a/crates/icy_net/src/connection/raw.rs
+++ b/crates/icy_net/src/connection/raw.rs
@@ -9,6 +9,7 @@ use tokio::{
 
 use crate::ConnectionState;
 
+use super::proxy::{ProxyConfig, connect_tcp};
 use super::{Connection, ConnectionType};
 
 pub struct RawConnection {
@@ -18,17 +19,22 @@ pub struct RawConnection {
 
 impl RawConnection {
     pub async fn open<A: ToSocketAddrs>(addr: &A, timeout: Duration) -> crate::Result<Self> {
-        let result = tokio::time::timeout(timeout, TcpStream::connect(addr)).await;
-        match result {
-            Ok(tcp_stream) => match tcp_stream {
-                Ok(stream) => Ok(Self {
-                    tcp_stream: stream,
-                    read_buffer: Vec::new(),
-                }),
-                Err(err) => Err(Box::new(err)),
-            },
-            Err(err) => Err(Box::new(err)),
-        }
+        let tcp_stream = tokio::time::timeout(timeout, TcpStream::connect(addr)).await??;
+        Ok(Self {
+            tcp_stream,
+            read_buffer: Vec::new(),
+        })
+    }
+
+    /// Like [`RawConnection::open`], but routes the TCP connection through an
+    /// optional proxy. The address must be given as `host:port` so that a SOCKS5
+    /// proxy can resolve the host remotely (`.onion` / `.i2p`).
+    pub async fn open_with_proxy(addr: &str, timeout: Duration, proxy: Option<&ProxyConfig>) -> crate::Result<Self> {
+        let tcp_stream = connect_tcp(addr, proxy, timeout).await?;
+        Ok(Self {
+            tcp_stream,
+            read_buffer: Vec::new(),
+        })
     }
 
     pub async fn accept(tcp_stream: TcpStream) -> crate::Result<Self> {

--- a/crates/icy_net/src/connection/rlogin.rs
+++ b/crates/icy_net/src/connection/rlogin.rs
@@ -33,6 +33,7 @@ use tokio::{
 
 use crate::telnet::TerminalEmulation;
 
+use super::proxy::{ProxyConfig, connect_tcp};
 use super::{Connection, ConnectionState, ConnectionType};
 
 /// Configuration for establishing an rlogin-style session.
@@ -117,15 +118,17 @@ impl RloginConnection {
     /// Returns a ready `RloginConnection`. Does not validate remote response;
     /// classic rlogin has minimal startup acknowledgement.
     pub async fn open(addr: impl Into<String>, cfg: RloginConfig, timeout: Duration) -> crate::Result<Self> {
+        Self::open_with_proxy(addr, cfg, timeout, None).await
+    }
+
+    /// Like [`RloginConnection::open`], but routes the TCP connection through an
+    /// optional proxy (SOCKS5 with remote DNS, for Tor/I2P).
+    pub async fn open_with_proxy(addr: impl Into<String>, cfg: RloginConfig, timeout: Duration, proxy: Option<&ProxyConfig>) -> crate::Result<Self> {
         let mut addr = addr.into();
         if !addr.contains(':') {
             addr.push_str(":513");
         }
-        let mut stream = match tokio::time::timeout(timeout, TcpStream::connect(addr)).await {
-            Ok(Ok(s)) => s,
-            Ok(Err(e)) => return Err(Box::new(e)),
-            Err(e) => return Err(Box::new(e)),
-        };
+        let mut stream = connect_tcp(&addr, proxy, timeout).await?;
         stream.set_nodelay(true)?;
 
         let terminal = cfg.terminal_str();

--- a/crates/icy_net/src/connection/ssh.rs
+++ b/crates/icy_net/src/connection/ssh.rs
@@ -19,8 +19,9 @@ use thiserror::Error;
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::ConnectionState;
+use crate::connection::proxy::{ProxyConfig, connect_tcp};
 use crate::{Connection, ConnectionType, telnet::TermCaps};
-use tokio::{io::AsyncWriteExt, net::TcpStream, sync::Mutex};
+use tokio::{io::AsyncWriteExt, sync::Mutex};
 
 pub struct SSHConnection {
     client: SshClient,
@@ -163,6 +164,8 @@ pub struct SshConnectionOptions {
     pub host_key_policy: HostKeyPolicy,
     pub connect_timeout: Duration,
     pub authentication_timeout: Duration,
+    /// Optional proxy for the underlying TCP connection (e.g. SOCKS5 for Tor/I2P).
+    pub proxy: Option<ProxyConfig>,
 }
 
 impl SshConnectionOptions {
@@ -174,6 +177,7 @@ impl SshConnectionOptions {
             host_key_policy: HostKeyPolicy::InsecureAcceptAny,
             connect_timeout: Duration::from_secs(5),
             authentication_timeout: Duration::from_secs(30),
+            proxy: None,
         }
     }
 }
@@ -501,10 +505,9 @@ impl SshClient {
             port,
             host_key_policy: options.host_key_policy,
         };
-        let tcp_stream = tokio::time::timeout(options.connect_timeout, TcpStream::connect(connect_addr))
+        let tcp_stream = connect_tcp(&connect_addr, options.proxy.as_ref(), options.connect_timeout)
             .await
-            .map_err(transport)?
-            .map_err(transport)?;
+            .map_err(SshAuthenticationError::Transport)?;
         tcp_stream.set_nodelay(true).map_err(transport)?;
         let mut session: client::Handle<Client> = russh::client::connect_stream(config, tcp_stream, sh).await.map_err(map_transport_error)?;
 
@@ -1231,6 +1234,7 @@ mod tests {
                 },
                 connect_timeout: Duration::from_secs(2),
                 authentication_timeout: Duration::from_secs(2),
+                proxy: None,
             },
         )
         .await;
@@ -1260,6 +1264,7 @@ mod tests {
                 host_key_policy: HostKeyPolicy::Fingerprint(SshHostKeyFingerprint(unrelated.public_key().fingerprint(ssh_key::HashAlg::Sha256).to_string())),
                 connect_timeout: Duration::from_secs(2),
                 authentication_timeout: Duration::from_secs(2),
+                proxy: None,
             },
         )
         .await;
@@ -1305,6 +1310,7 @@ mod tests {
                 host_key_policy: HostKeyPolicy::InsecureAcceptAny,
                 connect_timeout: Duration::from_secs(2),
                 authentication_timeout: Duration::from_millis(20),
+                proxy: None,
             },
         )
         .await;

--- a/crates/icy_net/src/connection/telnet/mod.rs
+++ b/crates/icy_net/src/connection/telnet/mod.rs
@@ -14,6 +14,7 @@ use tokio::{
 
 use crate::ConnectionState;
 
+use super::proxy::{ProxyConfig, connect_tcp};
 use super::{Connection, ConnectionType};
 
 mod negotiation;
@@ -116,18 +117,19 @@ pub struct TelnetConnection {
 
 impl TelnetConnection {
     pub async fn open(addr: impl Into<String>, caps: TermCaps, timeout: Duration) -> crate::Result<Self> {
+        Self::open_with_proxy(addr, caps, timeout, None).await
+    }
+
+    /// Like [`TelnetConnection::open`], but routes the TCP connection through an
+    /// optional proxy. With a SOCKS5 proxy the host name is resolved remotely, so
+    /// `.onion` and `.i2p` addresses work.
+    pub async fn open_with_proxy(addr: impl Into<String>, caps: TermCaps, timeout: Duration, proxy: Option<&ProxyConfig>) -> crate::Result<Self> {
         let mut addr: String = addr.into();
         if !addr.contains(':') {
             addr.push_str(":23");
         }
-        let result = tokio::time::timeout(timeout, TcpStream::connect(addr)).await;
-        match result {
-            Ok(tcp_stream) => match tcp_stream {
-                Ok(tcp_stream) => Ok(Self::new(tcp_stream, caps, false)),
-                Err(err) => Err(Box::new(err)),
-            },
-            Err(err) => Err(Box::new(err)),
-        }
+        let tcp_stream = connect_tcp(&addr, proxy, timeout).await?;
+        Ok(Self::new(tcp_stream, caps, false))
     }
 
     pub fn accept(tcp_stream: TcpStream) -> crate::Result<Self> {


### PR DESCRIPTION
  Adds optional per-connection SOCKS5 proxy support to `icy_net`, so callers can
  reach BBSes published as Tor `.onion` or I2P `.i2p` services.

  The key detail is **remote DNS**: the target hostname is handed to the proxy
  rather than resolved locally, which is what makes `.onion`/`.i2p` addresses
  resolvable at all.

  WebSocket connections are not proxied yet. It seemed better to leave that out than
  to bolt it on without testing it.